### PR TITLE
Always handle `null` as an empty result in API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed table entry properties to match API fields
+- Always handle `null` as an empty result in API responses to prevent mapping errors
 
 ## [1.0.2] - 2021-05-30
 

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -32,14 +32,6 @@ abstract class AbstractSerializer
         return null;
     }
 
-    /**
-     * Overwrite this in concrete serializers if the API returns null instead of an empty array.
-     */
-    protected function endpointReturnsNull(): bool
-    {
-        return false;
-    }
-
     private function validate(?object $json): ?string
     {
         if (null === $json) {
@@ -47,7 +39,7 @@ abstract class AbstractSerializer
         }
 
         // Check if root exists and contains data
-        if (null === $this->getJsonRootName($json) && !$this->endpointReturnsNull()) {
+        if (null === $this->getJsonRootName($json)) {
             return 'Wrong or empty root in JSON, expected one of ['
                 .implode(', ', $this->getValidJsonRootNames()).'] to contain data.';
         }
@@ -69,7 +61,7 @@ abstract class AbstractSerializer
         $innerJson = $json->{$this->getJsonRootName($json)};
 
         // Don't serialize if the API endpoint returned null instead of an empty array
-        if (null === $innerJson && $this->endpointReturnsNull()) {
+        if (null === $innerJson) {
             return [];
         }
 

--- a/src/Serializer/Event/EventSerializer.php
+++ b/src/Serializer/Event/EventSerializer.php
@@ -16,9 +16,4 @@ class EventSerializer extends AbstractSerializer
     {
         return ['event', 'events', 'results'];
     }
-
-    protected function endpointReturnsNull(): bool
-    {
-        return true;
-    }
 }

--- a/src/Serializer/Event/LivescoreSerializer.php
+++ b/src/Serializer/Event/LivescoreSerializer.php
@@ -16,9 +16,4 @@ class LivescoreSerializer extends AbstractSerializer
     {
         return ['events'];
     }
-
-    protected function endpointReturnsNull(): bool
-    {
-        return true;
-    }
 }

--- a/src/Serializer/LeagueSerializer.php
+++ b/src/Serializer/LeagueSerializer.php
@@ -15,9 +15,4 @@ class LeagueSerializer extends AbstractSerializer
     {
         return ['countrys', 'leagues'];
     }
-
-    protected function endpointReturnsNull(): bool
-    {
-        return true;
-    }
 }

--- a/src/Serializer/TeamSerializer.php
+++ b/src/Serializer/TeamSerializer.php
@@ -15,9 +15,4 @@ class TeamSerializer extends AbstractSerializer
     {
         return ['teams'];
     }
-
-    protected function endpointReturnsNull(): bool
-    {
-        return true;
-    }
 }

--- a/test/integration/ListTest.php
+++ b/test/integration/ListTest.php
@@ -151,6 +151,18 @@ class ListTest extends TestCase
     }
 
     /**
+     * @throws Exception
+     */
+    public function testPlayersNoMatch(): void
+    {
+        TestUtils::setPatreonKey($this->client);
+        $players = $this->client->list()->players(1);
+
+        $this->assertIsArray($players);
+        $this->assertEmpty($players);
+    }
+
+    /**
      * List all users loved teams and players (https://www.thesportsdb.com/api/v1/json/1/searchloves.php?u=zag).
      *
      * @throws Exception

--- a/test/unit/Serializer/ExtendedSerializerTest.php
+++ b/test/unit/Serializer/ExtendedSerializerTest.php
@@ -45,25 +45,25 @@ class ExtendedSerializerTest extends TestCase
     public function serializerProvider(): array
     {
         return [
-            [ContractSerializer::class, false],
-            [CountrySerializer::class, false],
-            [EntrySerializer::class, false],
-            [EventSerializer::class, true],
-            [FormerTeamSerializer::class, false],
-            [HighlightSerializer::class, false],
-            [HonorSerializer::class, false],
-            [LeagueSerializer::class, true],
-            [LineupSerializer::class, false],
-            [LivescoreSerializer::class, true],
-            [LoveSerializer::class, false],
-            [PlayerSerializer::class, false],
-            [ResultSerializer::class, false],
-            [SeasonSerializer::class, false],
-            [SportSerializer::class, false],
-            [StatisticSerializer::class, false],
-            [TeamSerializer::class, true],
-            [TelevisionSerializer::class, false],
-            [TimelineSerializer::class, false],
+            [ContractSerializer::class],
+            [CountrySerializer::class],
+            [EntrySerializer::class],
+            [EventSerializer::class],
+            [FormerTeamSerializer::class],
+            [HighlightSerializer::class],
+            [HonorSerializer::class],
+            [LeagueSerializer::class],
+            [LineupSerializer::class],
+            [LivescoreSerializer::class],
+            [LoveSerializer::class],
+            [PlayerSerializer::class],
+            [ResultSerializer::class],
+            [SeasonSerializer::class],
+            [SportSerializer::class],
+            [StatisticSerializer::class],
+            [TeamSerializer::class],
+            [TelevisionSerializer::class],
+            [TimelineSerializer::class],
         ];
     }
 
@@ -91,18 +91,5 @@ class ExtendedSerializerTest extends TestCase
 
         $this->assertNotEmpty($rootNames);
         $this->assertContainsOnly('string', $rootNames);
-    }
-
-    /**
-     * @dataProvider serializerProvider
-     *
-     * @param string $class       Class to test
-     * @param bool   $returnsNull Endpoint returns null or not
-     */
-    public function testEndpointReturnsNull(string $class, bool $returnsNull): void
-    {
-        $endpointReturnsNull =
-            TestUtils::getHiddenMethod(new $class(new JsonMapper()), 'endpointReturnsNull');
-        $this->assertSame($returnsNull, $endpointReturnsNull());
     }
 }


### PR DESCRIPTION
This prevents mapping exceptions.